### PR TITLE
Added url encoding for webhook values.

### DIFF
--- a/ESP8266Webhook.cpp
+++ b/ESP8266Webhook.cpp
@@ -20,30 +20,83 @@ SOFTWARE.
 
 #include "ESP8266Webhook.h"
 
-Webhook::Webhook(String api_key, String event_name){
+Webhook::Webhook(String api_key, String event_name)
+{
   _api_key = api_key;
   _event_name = event_name;
 }
 
-int Webhook::trigger(){
+int Webhook::trigger()
+{
   return Webhook::trigger("", "", "");
 }
 
-int Webhook::trigger(String value_1){
+int Webhook::trigger(String value_1)
+{
   return Webhook::trigger(value_1, "", "");
 }
 
-int Webhook::trigger(String value_1, String value_2){
+int Webhook::trigger(String value_1, String value_2)
+{
   return Webhook::trigger(value_1, value_2, "");
 }
 
-int Webhook::trigger(String value_1, String value_2, String value_3){
+int Webhook::trigger(String value_1, String value_2, String value_3)
+{
   WiFiClient client;
   HTTPClient http;
+  String encoded_value_1 = urlEncode(value_1);
+  String encoded_value_2 = urlEncode(value_2);
+  String encoded_value_3 = urlEncode(value_3);
   http.begin(client, "http://maker.ifttt.com/trigger/" +
-              _event_name+"/with/key/"+_api_key +
-              "?value1="+value_1+"&value2="+value_2+"&value3="+value_3);
+                         _event_name + "/with/key/" + _api_key +
+                         "?value1=" + encoded_value_1 + "&value2=" + encoded_value_2 + "&value3=" + encoded_value_3);
   int httpCode = http.GET();
   http.end();
   return httpCode;
+}
+
+/**
+ * Encode a string for URLs.
+ */
+String Webhook::urlEncode(String str)
+{
+  String encodedString = "";
+  char c;
+  char code0;
+  char code1;
+  char code2;
+  for (int i = 0; i < str.length(); i++)
+  {
+    c = str.charAt(i);
+    if (c == ' ')
+    {
+      encodedString += '+';
+    }
+    else if (isalnum(c))
+    {
+      encodedString += c;
+    }
+    else
+    {
+      code1 = (c & 0xf) + '0';
+      if ((c & 0xf) > 9)
+      {
+        code1 = (c & 0xf) - 10 + 'A';
+      }
+      c = (c >> 4) & 0xf;
+      code0 = c + '0';
+      if (c > 9)
+      {
+        code0 = c - 10 + 'A';
+      }
+      code2 = '\0';
+      encodedString += '%';
+      encodedString += code0;
+      encodedString += code1;
+      // encodedString+=code2;
+    }
+    yield();
+  }
+  return encodedString;
 }

--- a/ESP8266Webhook.h
+++ b/ESP8266Webhook.h
@@ -23,22 +23,23 @@ SOFTWARE.
 */
 
 #ifndef ESP8266Webhook_h
-  #define ESP8266Webhook_h
-  #include "Arduino.h"
-  #include <ESP8266HTTPClient.h>
-  #include <WiFiClient.h>
+#define ESP8266Webhook_h
+#include "Arduino.h"
+#include <ESP8266HTTPClient.h>
+#include <WiFiClient.h>
 
-  class Webhook
-  {
-    public:
-      Webhook(String api_key, String event_name);
-      int trigger(String value_1, String value_2, String value_3);
-      int trigger(String value_1, String value_2);
-      int trigger(String value_1);
-      int trigger();
+class Webhook
+{
+public:
+  Webhook(String api_key, String event_name);
+  int trigger(String value_1, String value_2, String value_3);
+  int trigger(String value_1, String value_2);
+  int trigger(String value_1);
+  int trigger();
+  String urlEncode(String str);
 
-    private:
-      String _api_key;
-      String _event_name;
-  };
+private:
+  String _api_key;
+  String _event_name;
+};
 #endif


### PR DESCRIPTION
When triggering a webhook with values, those values were not url-encoded and caused problems when reading them from within an action.

For example, when sending `"Your plant needs water! (26% moisture)"` as `value1` and reading the value within a [Notification action](https://ifttt.com/if_notifications/actions/send_notification), all of the spaces are missing from the value and other characters were incorrect.

This PR adds url-encoding to the three webhook values.

_Please forgive the extra formatting changes ... VSCode refuses to stop auto-formatting files on save 🙄_